### PR TITLE
Fix title and id mixup for systemd

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -76,7 +76,7 @@ class RebootQuickMenu extends QuickSettings.QuickMenuToggle {
                                 
                             }
                         });
-                    }, (x === 0)? "pan-end-symbolic" : undefined);
+                    }, (title === defaultOpt)? "pan-end-symbolic" : undefined);
                     x++;
                 });
                 this.menu.addMenuItem(this._itemsSection);

--- a/extension.js
+++ b/extension.js
@@ -17,7 +17,7 @@ const RebootQuickMenu = GObject.registerClass(
 class RebootQuickMenu extends QuickSettings.QuickMenuToggle {
     _init() {
         super._init({
-            label: 'Reboot Into...',
+            label: 'Reboot Into',
             iconName: 'system-reboot-symbolic',
             toggleMode: false,
         });
@@ -46,7 +46,7 @@ class RebootQuickMenu extends QuickSettings.QuickMenuToggle {
 
         // Set Menu Header
         this.menu.setHeader('system-reboot-symbolic', 'Boot Options',
-            'Grub');
+            'Reboot into the selected entry');
         
         // Add boot options to menu
         this.createBootMenu();

--- a/systemdBoot.js
+++ b/systemdBoot.js
@@ -45,7 +45,7 @@ async function getBootOptions() {
     try {
         let [status, stdout, stderr] = await Utils.execCommand([bootctl, "list"]);
         if (status !== 0)
-            throw new Error(`Failed to get list from bootctl: ${status}\n${stdout}\n${stderr}`) ;
+            throw new Error(`Failed to get list from bootctl: ${status}\n${stdout}\n${stderr}`);
         Utils._log(`bootctl list: ${status}\n${stdout}\n${stderr}`);
         let lines = String(stdout).split('\n');
         let titleRx = /(?<=title:\s+).+/;
@@ -59,11 +59,6 @@ async function getBootOptions() {
             let id = idRx.exec(l);
             if (title && title.length) {
                 titles.push(String(title));
-                let defaultRes = defaultRx.exec(title);
-                Utils._log('regex ' + defaultRes);
-                if(defaultRes && defaultRes.length){
-                    defaultOpt = String(title);
-                }
             } else if (id && id.length) {
                 ids.push(String(id));
             }
@@ -74,9 +69,17 @@ async function getBootOptions() {
         for (let i = 0; i < titles.length; i++) {
             bootOptions.set(ids[i], titles[i])
         }
-        bootOptions.forEach((v, k) => {
-            Utils._log(`${k} = ${v}`);
+
+        bootOptions.forEach((title, id) => {
+            Utils._log(`${id} = ${title}`);
+
+            let defaultRes = defaultRx.exec(title);
+
+            if (defaultRes) {
+                defaultOpt = id;
+            }
         })
+
         return [bootOptions, bootOptions.get(defaultOpt)];
     } catch (e) {
         logError(e);

--- a/systemdBoot.js
+++ b/systemdBoot.js
@@ -72,7 +72,7 @@ async function getBootOptions() {
             throw new Error("Number of titles and ids do not match!");
         let bootOptions = new Map();
         for (let i = 0; i < titles.length; i++) {
-            bootOptions.set(titles[i], ids[i])
+            bootOptions.set(ids[i], titles[i])
         }
         bootOptions.forEach((v, k) => {
             Utils._log(`${k} = ${v}`);


### PR DESCRIPTION
`title` and `id` were being mixed up for systemd and bootctl was attempting to boot using `title` rather than `id`. (It was also displaying ids rather than titles under entries.

 I've also committed a couple improvements for systemd usage.

- Removed grub specific sub heading.
- Fixed the default arrow always pointing to the first entry. (Is there anyone using grub that could check this is compatible?)
- Removed ellipsis from button.

**Before**

![image](https://user-images.githubusercontent.com/113969694/228505781-35b3a0c9-ddab-45c7-9e31-b66be048d72a.png)

**After**

![image](https://user-images.githubusercontent.com/113969694/228508384-e9c62f30-c17f-473e-98f9-d3fcdaf19e57.png)

