### PR TITLE
Add support for GNOME 44

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -17,7 +17,13 @@ const RebootQuickMenu = GObject.registerClass(
 class RebootQuickMenu extends QuickSettings.QuickMenuToggle {
     _init() {
         super._init({
+
+            // GNOME 44
+            title: 'Reboot Into',
+
+            // GNOME 43
             label: 'Reboot Into',
+
             iconName: 'system-reboot-symbolic',
             toggleMode: false,
         });
@@ -133,6 +139,12 @@ class Extension {
 
         // Add items to QuickSettingsMenu
         QuickSettingsMenu._addItems(this.quickSettingsItems);
+
+        // Ensure the tile(s) are above the background apps menu
+        for (const item of this.quickSettingsItems) {
+            QuickSettingsMenu.menu._grid.set_child_below_sibling(item,
+                QuickSettingsMenu._backgroundApps.quickSettingsItems[0]);
+        }
     }
 
     disable() {

--- a/metadata.json
+++ b/metadata.json
@@ -5,5 +5,5 @@
   "original-author": "Nova1545",
   "version": "4",
   "url": "https://github.com/Nova1545/gnome-shell-extension-customreboot",
-  "shell-version": [ "43" ]
+  "shell-version": [ "43", "44"]
 }


### PR DESCRIPTION
Adding support for GNOME 44 based on the guidance [here](https://gjs.guide/extensions/upgrading/gnome-shell-44.html#port-extensions-to-gnome-shell-44).

I have not tested this on GNOME 43.