### PR TITLE
catch failure on egibootmgr IsUsable check.

### DIFF
--- a/efibootmgr.js
+++ b/efibootmgr.js
@@ -59,8 +59,12 @@ async function SetBootOption(id) {
  * @returns True if usable otherwise false
  */
 async function IsUseable() {
-    let [status, stdout, stderr] = await Utils.execCommand(['efibootmgr'],);
-    return status === 0;
+    try {
+        let [status, stdout, stderr] = await Utils.execCommand(['efibootmgr'],);
+        return status === 0;
+    } catch (e) {
+        return false;
+    }
 }
 
 /**


### PR DESCRIPTION
This has been broken on systemd for a little while. Fixes an exception being thrown from `egibootmgr.IsUseable()` when efibootmgr is not installed.

Not logging the error message here since this is expected.

stack trace:
```
(gnome-shell:94114): Gjs-WARNING **: 17:10:09.386: Unhandled promise rejection. To suppress this warning, add an error handler to your promise chain with .catch() or a try-catch block around your await expression. Stack trace of the failed promise:
  createBootMenu@/home/sam/.local/share/gnome-shell/extensions/customreboot@nova1545/extension.js:53:25
  _init@/home/sam/.local/share/gnome-shell/extensions/customreboot@nova1545/extension.js:44:14
  QuickSettingsItem@resource:///org/gnome/shell/ui/quickSettings.js:23:4
  QuickMenuToggle@resource:///org/gnome/shell/ui/quickSettings.js:155:4
  RebootQuickMenu@/home/sam/.local/share/gnome-shell/extensions/customreboot@nova1545/extension.js:21:1
  enable@/home/sam/.local/share/gnome-shell/extensions/customreboot@nova1545/extension.js:158:38
  _callExtensionEnable@resource:///org/gnome/shell/ui/extensionSystem.js:196:38
  loadExtension@resource:///org/gnome/shell/ui/extensionSystem.js:398:32
  async*_loadExtensions@resource:///org/gnome/shell/ui/extensionSystem.js:677:24
  async*_enableAllExtensions@resource:///org/gnome/shell/ui/extensionSystem.js:683:48
  _sessionUpdated@resource:///org/gnome/shell/ui/extensionSystem.js:718:20
  async*init@resource:///org/gnome/shell/ui/extensionSystem.js:59:14
  _initializeUI@resource:///org/gnome/shell/ui/main.js:311:22
  start@resource:///org/gnome/shell/ui/main.js:186:5
  @resource:///org/gnome/shell/ui/init.js:6:17
  ```