### PR TITLE
Fix boot entry id regex for systemd boot

### DIFF
--- a/systemdBoot.js
+++ b/systemdBoot.js
@@ -23,7 +23,7 @@ export class SystemdBoot {
         Log(`bootctl list: ${status}\n${stdout}\n${stderr}`);
         let lines = String(stdout).split('\n');
         let titleRx = /(?<=title:\s+).+/;
-        let idRx = /(?<=id:\s+).+/;
+        let idRx = /(?<=(?:\s+|^)id:\s+).+/;
         let defaultRx = /\(default\)/;
         let titles = [];
         let ids = []


### PR DESCRIPTION
Linux boot entries may contain the `machine-id: ` line in their output. So, for such entries both `id:` and `machine-id:` lines would match the `idRx` regex (`/(?<=id:\s+).+/`), causing the process to crash with "Number of titles and ids do not match!" later on.


This patch makes the regex more strict to avoid that false positive match